### PR TITLE
feat: added celo mainnet and alfajores testnet

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,6 +56,8 @@ export const multicall3DeploymentBlockNumbers: { [chainId: number]: number } = {
   1442: 525686, // Polygon zkEVM Testnet
   8453: 5022, // Base
   84531: 1376988, // Base Testnet
+  42220: 13112599, // Celo Mainnet
+  42787: 14569001 // Celo Alfajores Testnet
 };
 
 export const multicall2DeploymentBlockNumbers: { [chainId: number]: number } = {


### PR DESCRIPTION
### Description of change

Added Chain IDs for Celo Mainnet and Celo Alfajores.

- [Multicall3 Contract on Celo Mainnet](https://celo.blockscout.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract)
- [Multicall3 Contract on Celo Alfajores](https://celo-alfajores.blockscout.com/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract)

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] ~~`npm run lint` passes with this change~~ (lint script doesn't exist anymore)
- [x] `npm run test` passes with this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
